### PR TITLE
Fix validation bug in partial_display_frame

### DIFF
--- a/libepd/epd2in7.py
+++ b/libepd/epd2in7.py
@@ -287,7 +287,7 @@ class EPD:
             pic_width = _nearest_integer_of_8(pic_width,round_up=True)
             x, y, w, l = x_start, y_start, pic_width, pic_height
 
-        if ( (x+w) > (self.width - 1)) or ( (y+l) > (self.height - 1)):
+        if ( (x+w) > (self.width)) or ( (y+l) > (self.height)):
               raise ValueError("reflash area is over the display area.")
 
         #crop


### PR DESCRIPTION
The validation logic in partial_display_frame is 1 pixel smaller than the full screen size - preventing the entire screen to be used during partial updates.

This fixes the validation bug when updating all the way to the edges of the screen.